### PR TITLE
Exception => StandardError

### DIFF
--- a/ruby.mustache
+++ b/ruby.mustache
@@ -78,7 +78,7 @@ def send_request
     res = http.request(req)
     puts "Response HTTP Status Code: #{res.code}"
     puts "Response HTTP Response Body: #{res.body}"
-  rescue Exception => e
+  rescue StandardError => e
     puts "HTTP Request failed (#{e.message})"
   end
 end


### PR DESCRIPTION
http://blog.honeybadger.io/ruby-exception-vs-standarderror-whats-the-difference/
https://robots.thoughtbot.com/rescue-standarderror-not-exception
http://stackoverflow.com/questions/10048173/why-is-it-bad-style-to-rescue-exception-e-in-ruby