### PR TITLE
Replace, rather than append headers

### DIFF
--- a/ruby.mustache
+++ b/ruby.mustache
@@ -57,9 +57,9 @@ def send_request
   req =  Net::HTTP::{{{method}}}{{#body.has_multipart_body}}::Multipart{{/body.has_multipart_body}}.new(uri{{#body.has_multipart_body}}, body{{/body.has_multipart_body}})
   {{! ----- }}
   {{#headers.has_headers}}
-  {{#headers.header_list}}
   # Add headers
-  req.add_field "{{{header_name}}}", "{{{header_value}}}"
+  {{#headers.header_list}}
+  req["{{{header_name}}}"] = "{{{header_value}}}"
   {{/headers.header_list}}
   {{/headers.has_headers}}
   {{! ----- }}


### PR DESCRIPTION
I was trying to set an XML Accept header but the server was seeing it as HTML. It looks like the issue is using [`add_field`](http://ruby-doc.org/stdlib-2.4.0/libdoc/net/http/rdoc/Net/HTTPHeader.html#method-i-add_field) since it:
> Adds a value to a named header field, instead of replacing its value. 

I think we'd actually want to be using the hash syntax to replace the values since Paw seems to merge multiple headers into one value.

You can see the issue using output of the current code:
```rb
require 'net/http'
require 'net/https'

uri = URI('https://echo.paw.cloud/')

# Create client
http = Net::HTTP.new(uri.host, uri.port)
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_PEER

# Create Request
req =  Net::HTTP::Get.new(uri)
# Add headers
req.add_field "Accept", "application/xml"

puts req["accept"]
```
Will output: `*/*, application/xml`

This version should output something more like:
```rb
require 'net/http'
require 'net/https'

uri = URI('https://echo.paw.cloud/')

# Create client
http = Net::HTTP.new(uri.host, uri.port)
http.use_ssl = true
http.verify_mode = OpenSSL::SSL::VERIFY_PEER

# Create Request
req =  Net::HTTP::Get.new(uri)
# Add headers
req["Accept"] = "application/xml"

puts req["accept"]
```
Will output: `application/xml`
